### PR TITLE
Changing contact and footer sections to be editable

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -11,6 +11,7 @@ const Contact = () => {
   const [subject, setSubject] = useState("");
   const [message, setMessage] = useState("");
   const [nupepEmail, setNupepEmail] = useState("")
+  const [contactText, setContactText] = useState("")
 
   const getEmail = async () => {
     const result = await axios.get('https://nupepcms.articadev.com/api/contact-email');
@@ -19,8 +20,16 @@ const Contact = () => {
     }
   };
 
+  const getContactText = async () => {
+    const result = await axios.get('https://nupepcms.articadev.com/api/contact');
+    if (result) {
+      setContactText(result.data.data.attributes.Texto);
+    }
+  };
+
   useEffect(() => {
     getEmail()
+    getContactText()
   }, [])
 
   const alert = useAlert();
@@ -95,18 +104,7 @@ const Contact = () => {
               <Title>
                 Informações para <span className="text-blue">contato</span>
               </Title>
-              <p className="text-xl font-bold lg:w-150">
-                Núcleo de Pesquisa em Eletrônica de Potência (NUPEP) Faculdade
-                de Engenharia Elétrica (FEELT)
-                <br /> Universidade Federal de Uberlândia (UFU)
-                <br /> Av. João Naves de Ávila 2121, Campus Santa Mônica - Bloco
-                1P - 1º Andar.
-                <br /> Uberlândia MG - CEP 38400-902
-                <br />
-                Telefones: +55 34-3239-4701 +55 34-3239-4767
-                <br /> Fax: 34-3239-4704
-                <br />
-                E-mail: lcgfreitas@yahoo.com.br
+              <p className="text-xl font-bold lg:w-150" dangerouslySetInnerHTML={{ __html: contactText }}>
               </p>
             </div>
           </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,21 @@
 import ufu from "../assets/ufu.png";
+import axios from 'axios';
+import { useState, useEffect } from "react";
 
 const Footer = () => {
+  const [contactText, setContactText] = useState("")
+
+  const getContactText = async () => {
+    const result = await axios.get('https://nupepcms.articadev.com/api/footer');
+    if (result) {
+      setContactText(result.data.data.attributes.Texto);
+    }
+  };
+
+  useEffect(() => {
+    getContactText()
+  }, [])
+
   const urlList = [
     {
       name: "IEEE IAS",
@@ -30,14 +45,7 @@ const Footer = () => {
 
   return (
     <div className="max-w-screen mt-28 grid grid-flow-row items-center justify-center gap-2 bg-[#161616] p-10 font-bold text-white">
-      <p>
-        Núcleo de Pesquisa em Eletrônica de Potência (NUPEP) - Universidade
-        Federal de Uberlândia (UFU)
-      </p>
-      <p>
-        Av. João Naves de Ávila 2121 - Campus Santa Mônica - Bloco 1P -
-        Uberlândia MG - CEP 38400902
-      </p>
+      <p dangerouslySetInnerHTML={{ __html: contactText }}></p>
       <a href="callto:3432394411">+55 34 3239-4411 | +55 34 3218-2111</a>
       <div className="grid grid-flow-col items-center gap-5 lg:justify-between">
         <div>


### PR DESCRIPTION
As stated at the issue #10, we want to be able to edit the footer and contact sections text. Hence, as the CMS already had this fields implemented, this PR changes the components to fetch content from there.